### PR TITLE
Correctly exclude sushi and univ3 on celo

### DIFF
--- a/src/components/swap/routing/hooks/useTrade.ts
+++ b/src/components/swap/routing/hooks/useTrade.ts
@@ -9,6 +9,7 @@ import { ERC20_ABI } from '../../../../constants/abis/erc20'
 import {
   BASES_TO_CHECK_TRADES_AGAINST,
   BETTER_TRADE_LESS_HOPS_THRESHOLD,
+  DEXES_TO_EXCLUDE,
   FETCH_MINIMA_ROUTER_TIMER,
   MINIMA_API_URL,
   UBESWAP_MOOLA_ROUTER_ADDRESS,
@@ -330,6 +331,7 @@ export function useMinimaTrade(tokenAmountIn?: TokenAmount, tokenOut?: Token): M
   const library = useProvider()
   const provider = getProviderOrSigner(library, account || undefined)
   const tokens = useAllTokens()
+
   const call = React.useCallback(async () => {
     if (!tokenAmountIn?.currency.address || !tokenAmountIn?.raw || !tokenOut?.address) {
       setMinimaTrade(null)
@@ -355,7 +357,7 @@ export function useMinimaTrade(tokenAmountIn?: TokenAmount, tokenOut?: Token): M
     setFetchUpdatedData(false)
     // fetch information of minima router
     await fetch(
-      `${MINIMA_API_URL}?tokenIn=${tokenAmountIn?.currency.address ?? ''}&tokenOut=${
+      `${MINIMA_API_URL}?exclude=${DEXES_TO_EXCLUDE}&tokenIn=${tokenAmountIn?.currency.address ?? ''}&tokenOut=${
         tokenOut?.address ?? ''
       }&amountIn=${tokenAmountIn?.raw}&slippage=${allowedSlippage}&maxHops=${
         singleHopOnly ? 1 : MAX_HOPS

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -204,3 +204,9 @@ export const IMPORTED_FARMS = 'imported_farms'
 export const MINIMA_API_URL = 'https://router.nodefinance.org/routes'
 
 export const FETCH_MINIMA_ROUTER_TIMER = 5000
+
+export const DEXES_TO_EXCLUDE = [
+  'sushiswap',
+  'uniswap-v3',
+  ...(process.env.REACT_APP_DEX_EXCLUSION_LIST?.split(',') ?? []),
+]


### PR DESCRIPTION
In order to exclude univ3 and sushi in all cases, it is best to include the `exclude` flag in the request.

Do note:  The package did not build for me (before and after making any changes), so I have not been able to verify proper functionality. 